### PR TITLE
build(tsc): add explicit rootDir to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "DOM"
     ],
     "outDir": "./dist",
+    "rootDir": "./src",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "moduleResolution": "Node",


### PR DESCRIPTION
## Summary

- Adds explicit `"rootDir": "./src"` to `tsconfig.json` to remove the TS5011 warning from clean builds.

## Motivation

TypeScript 5.8+ emits this warning on every build:

\`\`\`
tsconfig.json(11,5): error TS5011: The common source directory of
'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly
set to this or another path to adjust your output's file layout.
\`\`\`

The inferred `rootDir` already is `./src` (matching the existing `include: ["src/**/*"]`), so this is a documentation-only change that silences the warning. No compiled output changes — `dist/catalyst.mjs` is byte-identical before and after.

## Test plan

- [x] `npm ci && npm run build` — produces `dist/catalyst.mjs`
- [x] `diff` of `dist/` before and after shows no functional change
- [x] TS5011 no longer appears in tsc output

## Notes

Two pre-existing warnings remain (`Cannot find namespace 'dagre'` and two implicit-`any` params in `src/layout/LayoutEngine.mts`) — those are unrelated and don't block emit. Happy to file a follow-up PR if useful.