### PR TITLE
fix(puml): accept 3-arg Rel + BiRel/Rel_Back/Rel_U/D/L/R variants

### DIFF
--- a/src/puml/RelParser.mts
+++ b/src/puml/RelParser.mts
@@ -22,16 +22,18 @@ class RelParser {
     static getRelations(pumlString: string): Array<{ source: string, target: string, label: string, description: string }> {
         const relations: Array<{ source: string, target: string, label: string, description: string }> = [];
 
-        // Define the regular expression pattern to match relations
-        const relationPattern = /Rel\(([^,]+),\s*([^,]+),\s*"([^"]+)",\s*"([^"]+)"\)/g;
+        // Accept every C4-PlantUML relationship primitive: Rel, BiRel, Rel_Back,
+        // Rel_U/D/L/R (directional hints), Rel_Neighbor. The 4th positional arg
+        // (technology/description) is optional — `Rel(src, tgt, "label")` is
+        // equally valid in C4-PlantUML.
+        const relationPattern = /(?:Rel|BiRel|Rel_Back|Rel_U|Rel_D|Rel_L|Rel_R|Rel_Neighbor)\(\s*([^,\s)]+)\s*,\s*([^,\s)]+)\s*,\s*"([^"]*)"(?:\s*,\s*"([^"]*)")?\s*\)/g;
 
-        // Find all matches of relations in the C4 diagram string
         let match;
         while ((match = relationPattern.exec(pumlString)) !== null) {
             const source = match[1].trim();
             const target = match[2].trim();
             const label = match[3].trim();
-            const description = match[4].trim();
+            const description = (match[4] ?? '').trim();
 
             relations.push({
                 source,


### PR DESCRIPTION
## Summary

- Widens `RelParser.getRelations` to accept the full C4-PlantUML relationship set: `Rel`, `BiRel`, `Rel_Back`, `Rel_U/D/L/R`, `Rel_Neighbor`.
- Makes the 4th positional arg (technology/description) optional so 3-arg `Rel(src, tgt, "label")` calls parse correctly.

## Why

The previous regex required exactly 4 args, so every 3-arg `Rel(...)` and every non-plain `Rel`-variant was silently dropped. This alone accounts for most of the missing edges in real C4-PlantUML diagrams.

## Repro (from tracking issue #554)

\`\`\`plantuml
Rel(a, b, "Uses")               # 3-arg: dropped before
Rel(a, b, "Uses", "HTTPS")      # 4-arg: already worked
BiRel(a, b, "Talks", "gRPC")    # BiRel: dropped before
\`\`\`

## Test plan

- [x] Existing `RelParser.test.mts` still passes
- [x] Verified against real C4 context + container diagrams in a downstream consumer

Refs: #554 (gap 1/5).