### PR TITLE
fix(mx): emit diagram id + name so drawio-export accepts the XML

### DIFF
--- a/src/mx/Mx.mts
+++ b/src/mx/Mx.mts
@@ -28,6 +28,12 @@ class Mx {
                     type: 'atlas'
                 },
                 diagram: {
+                    // Emit id + name so drawio-export / drawio-desktop headless
+                    // tools accept the XML (they reject bare <diagram>).
+                    $: {
+                        id: 'catalyst-diagram',
+                        name: 'Page-1'
+                    },
                     MxGraphModel: {
                         $: {
                             pageHeight: diagramHeight,

--- a/src/mx/MxFile.interface.mts
+++ b/src/mx/MxFile.interface.mts
@@ -7,6 +7,10 @@ export interface MxFile {
             type: string;
         };
         diagram: {
+            $?: {
+                id?: string;
+                name?: string;
+            };
             MxGraphModel: MxGraphModel;
         };
     };


### PR DESCRIPTION
## Summary

- `Mx.mts` now emits `<diagram id="catalyst-diagram" name="Page-1">` instead of a bare `<diagram>`.
- `MxFile.interface.mts` declares the optional `$` attribute bag on the diagram node.

## Why

Bare `<diagram>` is rejected by `rlespinasse/drawio-export` and some drawio-desktop headless tooling with `missing field '@id'`. drawio Desktop GUI is lenient but imports it as an unnamed page. Adding id+name costs 10 lines and unlocks every headless-export pipeline.

## Test plan

- [x] All existing tests pass
- [x] Verified `drawio-export` accepts the output and produces PNGs

Refs: #554 (gap 5/5).