### PR TITLE
fix(puml): accept *_Boundary types + paren-aware argument parsing

### DIFF
--- a/src/puml/EntityParser.mts
+++ b/src/puml/EntityParser.mts
@@ -24,29 +24,72 @@ class EntityParser {
       'Component_Ext',
       'ComponentDb_Ext',
       'ComponentQueue_Ext',
+      // Boundary containers — parsed as stack frames (block ends with '{')
+      // and emitted as dashed clusters that enclose their children.
+      'System_Boundary',
+      'Container_Boundary',
+      'Enterprise_Boundary',
+      'Boundary',
     ].indexOf(type) !== -1 ? true : false
   }
 
   private isComponent(str: string): boolean {
-    return str.match(/^(?!Rel\b|UpdateElementStyle\b|UpdateSystemBoundaryStyle\b|AddRelTag\b|AddElementTag\b|scale\b|title\b|LAYOUT_TOP_DOWN\b|SHOW_LEGEND\b|[@!]).*$/) === null;
+    return str.match(/^(?!Rel\b|BiRel\b|UpdateElementStyle\b|UpdateSystemBoundaryStyle\b|AddRelTag\b|AddElementTag\b|Lay_[UDLR]\b|Lay_Distance\b|scale\b|title\b|LAYOUT_TOP_DOWN\b|LAYOUT_LEFT_RIGHT\b|LAYOUT_WITH_LEGEND\b|SHOW_LEGEND\b|SHOW_FLOATING_LEGEND\b|HIDE_STEREOTYPE\b|[@!]).*$/) === null;
   }
 
   private parseBlock(parent: string, block: string): EntityDescriptor | null {
-    const matchNode = /^(.*)\((.*)\)/;
-    const props = block.match(matchNode)?.[2].split(',').map((prop) => prop.trim());
-
-    if (!props) {
-      // Handle invalid input here.
+    // Extract type name + argument list with paren-depth awareness so that
+    // descriptions containing `(nested)` text don't confuse a greedy regex.
+    const openIdx = block.indexOf('(');
+    if (openIdx < 0) {
+      return null;
+    }
+    const typeName = block.slice(0, openIdx).trim();
+    let depth = 0;
+    let closeIdx = -1;
+    for (let i = openIdx; i < block.length; i++) {
+      if (block[i] === '(') depth++;
+      else if (block[i] === ')') {
+        depth--;
+        if (depth === 0) {
+          closeIdx = i;
+          break;
+        }
+      }
+    }
+    if (closeIdx < 0) {
       return null;
     }
 
-    if(!this.isValidEntityType(block.match(matchNode)![1])) {
-      return null
+    if (!this.isValidEntityType(typeName)) {
+      return null;
+    }
+
+    // Split the argument list on top-level commas only (skip commas inside
+    // nested parens that survived the quote-strip step upstream).
+    const argsStr = block.slice(openIdx + 1, closeIdx);
+    const props: string[] = [];
+    let buf = '';
+    let nested = 0;
+    for (const ch of argsStr) {
+      if (ch === '(') nested++;
+      else if (ch === ')') nested--;
+      if (ch === ',' && nested === 0) {
+        props.push(buf.trim());
+        buf = '';
+      } else {
+        buf += ch;
+      }
+    }
+    if (buf.trim().length > 0) props.push(buf.trim());
+
+    if (props.length === 0) {
+      return null;
     }
 
     const result: EntityDescriptor = {
       parent,
-      type: block.match(matchNode)![1],
+      type: typeName,
       alias: props[0],
       label: props[1],
     };

--- a/tests/puml/EntityParser.test.mts
+++ b/tests/puml/EntityParser.test.mts
@@ -99,11 +99,15 @@ describe('EntityParser', () => {
       }
     `;
     const result = parser.parse(input);
-    
-    // The parser doesn't recognize System_Boundary as a valid type, so containers are parsed separately
-    expect(result).toHaveLength(2);
-    expect(result[0].alias).toBe('container1');
-    expect(result[1].alias).toBe('container2');
+
+    // System_Boundary is a valid entity type; it becomes the hierarchy parent
+    // and the two containers are its children.
+    expect(result).toHaveLength(1);
+    expect(result[0].alias).toBe('boundary1');
+    expect(result[0].type).toBe('System_Boundary');
+    expect(result[0].children).toHaveLength(2);
+    expect(result[0].children![0].alias).toBe('container1');
+    expect(result[0].children![1].alias).toBe('container2');
   });
 
   it('should find object with property and value in hierarchy', () => {
@@ -265,10 +269,13 @@ describe('EntityParser', () => {
       System(system2, "System 2")
     `;
     const result = parser.parse(input);
-    
-    // System_Boundary is not a valid entity type, so only the systems should be parsed
+
+    // System_Boundary encloses system1; system2 is a peer at the root.
     expect(result).toHaveLength(2);
-    expect(result[0].alias).toBe('system1');
+    expect(result[0].alias).toBe('boundary1');
+    expect(result[0].type).toBe('System_Boundary');
+    expect(result[0].children).toHaveLength(1);
+    expect(result[0].children![0].alias).toBe('system1');
     expect(result[1].alias).toBe('system2');
   });
 


### PR DESCRIPTION
## Summary

Two related EntityParser fixes:

1. **Accept `System_Boundary` / `Container_Boundary` / `Enterprise_Boundary` / `Boundary`** as valid entity types. Without this, boundary blocks parsed via the `{` branch returned `null`, and children lost their parent linkage.

2. **Rewrite `parseBlock` with a paren-depth-aware tokenizer.** The previous greedy `/^(.*)\((.*)\)/` regex mis-parsed any argument whose value contained literal parens (e.g. `"Allocates IPs (primary; fallback)"`), silently dropping the entity.

Also extends `isComponent` to skip `BiRel`, `Lay_[UDLR]`, `Lay_Distance`, `LAYOUT_*`, `SHOW_FLOATING_LEGEND`, `HIDE_STEREOTYPE` — directives that were previously treated as entity candidates.

## Test plan

- [x] Two existing tests updated to reflect new (correct) boundary behavior — they were asserting the old bug.
- [x] All 107 existing tests pass
- [x] Paren-aware tokenizer tested against `Container(lb, "name", "desc", "IPs (primary; fallback via X=y)")` — now parses correctly.

Refs: #554 (gaps 2/5 and 4/5).