### PR TITLE
feat(c4): render Person/System_Ext/ContainerDb/Boundary + broaden layoutData2mx switch

### DIFF
--- a/src/catalyst.mts
+++ b/src/catalyst.mts
@@ -5,48 +5,42 @@ import { LayoutEngine, LayoutResult } from './layout/LayoutEngine.mjs'
 
 async function layoutData2mx(layoutData: LayoutResult, pumlElements: EntityDescriptor[], pumlRelations: { source: string, target: string, label: string, description: string }[]): Promise<string> {
   const mx = new Mx(layoutData.height || 600, layoutData.width || 800)
-  
-  // Handle nodes from layout data
+  const parser = new EntityParser()
+
+  // Build alias → parent-alias map by walking the entity hierarchy once.
+  // Used to preserve drawio containment (e.g. Container inside System_Boundary).
+  const parentOf = new Map<string, string>()
+  const walk = (entities: EntityDescriptor[], parent?: string) => {
+    for (const e of entities) {
+      if (parent) parentOf.set(e.alias, parent)
+      if (e.children) walk(e.children, e.alias)
+    }
+  }
+  walk(pumlElements)
+
+  // Handle nodes from layout data. Pass every valid C4 type through — Mx.addMxC4's
+  // switch decides the shape/style. `default: break` here would drop Persons,
+  // System_Ext, ContainerDb, etc.
   if (layoutData.nodes && Array.isArray(layoutData.nodes)) {
     for (const node of layoutData.nodes) {
       const g = new MxGeometry(node.height, node.width, node.x, node.y)
-      const info = new EntityParser().getObjectWithPropertyAndValueInHierarchy(pumlElements, 'alias', node.id)
+      const info = parser.getObjectWithPropertyAndValueInHierarchy(pumlElements, 'alias', node.id)
 
       if (info) {
-        switch (info.type) {
-          case 'System':
-            await mx.addMxC4(node.id, g, 'System', info.label, info.technology, info.description)
-            break
-          case 'Container':
-            await mx.addMxC4(node.id, g, 'Container', info.label, info.technology, info.description)
-            break
-          case 'Component':
-            await mx.addMxC4(node.id, g, 'Component', info.label, info.technology, info.description)
-            break
-          default:
-            break
-        }
+        await mx.addMxC4(node.id, g, info.type, info.label, info.technology, info.description, parentOf.get(node.id))
       }
     }
   }
 
-  // Handle clusters from layout data
+  // Handle clusters from layout data — same treatment. Boundaries land here
+  // (they're stack frames in the PUML and always have children).
   if (layoutData.clusters && Array.isArray(layoutData.clusters)) {
     for (const cluster of layoutData.clusters) {
       const g = new MxGeometry(cluster.height, cluster.width, cluster.x, cluster.y)
-      const info = new EntityParser().getObjectWithPropertyAndValueInHierarchy(pumlElements, 'alias', cluster.id)
+      const info = parser.getObjectWithPropertyAndValueInHierarchy(pumlElements, 'alias', cluster.id)
 
       if (info) {
-        switch (info.type) {
-          case 'System':
-            await mx.addMxC4(cluster.id, g, 'System', info.label, info.technology, info.description)
-            break
-          case 'Container':
-            await mx.addMxC4(cluster.id, g, 'Container', info.label, info.technology, info.description)
-            break
-          default:
-            break
-        }
+        await mx.addMxC4(cluster.id, g, info.type, info.label, info.technology, info.description, parentOf.get(cluster.id))
       }
     }
   }

--- a/src/mx/Mx.mts
+++ b/src/mx/Mx.mts
@@ -5,6 +5,11 @@ import type { c4 } from './c4/c4.interface.mjs';
 import { System } from './c4/System.mjs';
 import { Component } from './c4/Component.mjs';
 import { Container } from './c4/Container.mjs';
+import { ContainerDb } from './c4/ContainerDb.mjs';
+import { Person } from './c4/Person.mjs';
+import { PersonExt } from './c4/PersonExt.mjs';
+import { SystemExt } from './c4/SystemExt.mjs';
+import { Boundary } from './c4/Boundary.mjs';
 import { Relastionship } from './c4/Relationship.mjs';
 
 class Mx {
@@ -47,26 +52,85 @@ class Mx {
         return this.doc.MxFile.diagram.MxGraphModel.root
     }
 
-    async addMxC4(alias: string, geometry: MxGeometry, type: string, name: string, technology?: string, description?: string): Promise<void> {
+    async addMxC4(alias: string, geometry: MxGeometry, type: string, name: string, technology?: string, description?: string, parent?: string): Promise<void> {
 
         let c4Type = ''
         let label = ''
         let style = ''
         switch (type) {
+            case 'Person':
+                c4Type = 'Person'
+                label = await Person.label()
+                style = Person.style()
+                break;
+            case 'Person_Ext':
+                c4Type = 'Person_Ext'
+                label = await PersonExt.label()
+                style = PersonExt.style()
+                break;
             case 'System':
                 c4Type = 'System'
                 label = await System.label()
                 style = System.style()
+                break;
+            case 'SystemDb':
+            case 'SystemQueue':
+                // Reuse Container cylinder styling for DB/Queue variants until
+                // dedicated shape classes are added.
+                c4Type = type
+                label = await ContainerDb.label()
+                style = ContainerDb.style()
+                break;
+            case 'System_Ext':
+            case 'SystemDb_Ext':
+            case 'SystemQueue_Ext':
+                c4Type = type
+                label = await SystemExt.label()
+                style = SystemExt.style()
                 break;
             case 'Container':
                 c4Type = 'Container'
                 label = await Container.label()
                 style = Container.style()
                 break;
+            case 'ContainerDb':
+            case 'ContainerQueue':
+                c4Type = type
+                label = await ContainerDb.label()
+                style = ContainerDb.style()
+                break;
+            case 'Container_Ext':
+            case 'ContainerDb_Ext':
+            case 'ContainerQueue_Ext':
+                c4Type = type
+                label = await SystemExt.label()
+                style = SystemExt.style()
+                break;
             case 'Component':
                 c4Type = 'Component'
                 label = await Component.label()
                 style = Component.style()
+                break;
+            case 'ComponentDb':
+            case 'ComponentQueue':
+                c4Type = type
+                label = await ContainerDb.label()
+                style = ContainerDb.style()
+                break;
+            case 'Component_Ext':
+            case 'ComponentDb_Ext':
+            case 'ComponentQueue_Ext':
+                c4Type = type
+                label = await SystemExt.label()
+                style = SystemExt.style()
+                break;
+            case 'System_Boundary':
+            case 'Container_Boundary':
+            case 'Enterprise_Boundary':
+            case 'Boundary':
+                c4Type = type
+                label = await Boundary.label()
+                style = Boundary.style()
                 break;
 
             default:
@@ -86,7 +150,7 @@ class Mx {
             MxCell: {
                 $: {
                     style,
-                    parent: "1",
+                    parent: parent || "1",
                     vertex: 1
                 },
                 MxGeometry: geometry
@@ -141,4 +205,4 @@ class Mx {
     }
 }
 
-export { Mx, MxGeometry, Relastionship, System, Component, Container }
+export { Mx, MxGeometry, Relastionship, System, SystemExt, Component, Container, ContainerDb, Person, PersonExt, Boundary }

--- a/src/mx/c4/Boundary.mts
+++ b/src/mx/c4/Boundary.mts
@@ -1,0 +1,40 @@
+class Boundary {
+    static async label() {
+        const html = `<div style="font-weight:bold;">%c4Name%</div><div style="font-size:11px;">[%c4Type%]</div>`;
+        const minifiedHtml = html.replace(/>\s+</g, '><');
+        return this.encodeHtmlEntities(minifiedHtml);
+    }
+
+    private static encodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    static style() {
+        const styles: Record<string, unknown> = {
+            rounded: 0,
+            whiteSpace: 'wrap',
+            html: 1,
+            dashed: 1,
+            labelBackgroundColor: 'none',
+            strokeColor: '#666666',
+            fillColor: 'none',
+            fontColor: '#333333',
+            align: 'center',
+            verticalAlign: 'top',
+            fontStyle: 0,
+            fontSize: 12,
+            metaEdit: 1,
+            resizable: 1,
+            container: 1,
+            collapsible: 0,
+        }
+        return Object.entries(styles).map(([key, value]) => `${key}=${value}`).join(';');
+    }
+}
+
+export { Boundary }

--- a/src/mx/c4/ContainerDb.mts
+++ b/src/mx/c4/ContainerDb.mts
@@ -1,0 +1,36 @@
+class ContainerDb {
+    static async label() {
+        const html = `<div style="font-size:16px;font-weight:bold;">%c4Name%</div><div>[%c4Type%:%c4Technology%]</div><div style="font-size:11px;color:#cccccc;">%c4Description%</div>`;
+        const minifiedHtml = html.replace(/>\s+</g, '><');
+        return this.encodeHtmlEntities(minifiedHtml);
+    }
+
+    private static encodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    static style() {
+        const styles: Record<string, unknown> = {
+            shape: 'cylinder3',
+            whiteSpace: 'wrap',
+            html: 1,
+            boundedLbl: 1,
+            labelBackgroundColor: 'none',
+            fillColor: '#23A2D9',
+            fontColor: '#ffffff',
+            strokeColor: '#0E7DAD',
+            align: 'center',
+            verticalAlign: 'top',
+            metaEdit: 1,
+            resizable: 1,
+        }
+        return Object.entries(styles).map(([key, value]) => `${key}=${value}`).join(';');
+    }
+}
+
+export { ContainerDb }

--- a/src/mx/c4/Person.mts
+++ b/src/mx/c4/Person.mts
@@ -1,0 +1,35 @@
+class Person {
+    static async label() {
+        const html = `<div style="font-size:16px;font-weight:bold;">%c4Name%</div><div>[%c4Type%]</div><div style="font-size:11px;color:#cccccc;">%c4Description%</div>`;
+        const minifiedHtml = html.replace(/>\s+</g, '><');
+        return this.encodeHtmlEntities(minifiedHtml);
+    }
+
+    private static encodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    static style() {
+        const styles: Record<string, unknown> = {
+            shape: 'mxgraph.c4.person2',
+            align: 'center',
+            html: 1,
+            labelBackgroundColor: 'none',
+            fillColor: '#08427B',
+            fontColor: '#ffffff',
+            strokeColor: '#073B6F',
+            verticalAlign: 'top',
+            whiteSpace: 'wrap',
+            metaEdit: 1,
+            resizable: 1,
+        }
+        return Object.entries(styles).map(([key, value]) => `${key}=${value}`).join(';');
+    }
+}
+
+export { Person }

--- a/src/mx/c4/PersonExt.mts
+++ b/src/mx/c4/PersonExt.mts
@@ -1,0 +1,35 @@
+class PersonExt {
+    static async label() {
+        const html = `<div style="font-size:16px;font-weight:bold;">%c4Name%</div><div>[%c4Type%]</div><div style="font-size:11px;color:#cccccc;">%c4Description%</div>`;
+        const minifiedHtml = html.replace(/>\s+</g, '><');
+        return this.encodeHtmlEntities(minifiedHtml);
+    }
+
+    private static encodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    static style() {
+        const styles: Record<string, unknown> = {
+            shape: 'mxgraph.c4.person2',
+            align: 'center',
+            html: 1,
+            labelBackgroundColor: 'none',
+            fillColor: '#686868',
+            fontColor: '#ffffff',
+            strokeColor: '#4D4D4D',
+            verticalAlign: 'top',
+            whiteSpace: 'wrap',
+            metaEdit: 1,
+            resizable: 1,
+        }
+        return Object.entries(styles).map(([key, value]) => `${key}=${value}`).join(';');
+    }
+}
+
+export { PersonExt }

--- a/src/mx/c4/SystemExt.mts
+++ b/src/mx/c4/SystemExt.mts
@@ -1,0 +1,36 @@
+class SystemExt {
+    static async label() {
+        const html = `<div style="font-size:16px;font-weight:bold;">%c4Name%</div><div>[%c4Type%:%c4Technology%]</div><div style="font-size:11px;color:#cccccc;">%c4Description%</div>`;
+        const minifiedHtml = html.replace(/>\s+</g, '><');
+        return this.encodeHtmlEntities(minifiedHtml);
+    }
+
+    private static encodeHtmlEntities(str: string): string {
+        return str
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    static style() {
+        const styles: Record<string, unknown> = {
+            rounded: 1,
+            whiteSpace: 'wrap',
+            html: 1,
+            labelBackgroundColor: 'none',
+            fillColor: '#8C8496',
+            fontColor: '#ffffff',
+            align: 'center',
+            verticalAlign: 'top',
+            arcSize: 10,
+            strokeColor: '#736782',
+            metaEdit: 1,
+            resizable: 1,
+        }
+        return Object.entries(styles).map(([key, value]) => `${key}=${value}`).join(';');
+    }
+}
+
+export { SystemExt }

--- a/tests/export-gaps.test.mts
+++ b/tests/export-gaps.test.mts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Catalyst } from '../src/catalyst.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) =>
+    readFileSync(join(__dirname, 'fixtures', name), 'utf-8');
+
+describe('end-to-end export coverage for real C4-PlantUML diagrams', () => {
+    it('emits diagram id + name so drawio-export accepts the XML', async () => {
+        const xml = await Catalyst.convert(fixture('c4-context.puml'));
+        expect(xml).toMatch(/<diagram\s+id="[^"]+"\s+name="[^"]+"/);
+    });
+
+    it('preserves Person + System_Ext + System_Boundary shapes + all 4 Rels in c4-context', async () => {
+        const xml = await Catalyst.convert(fixture('c4-context.puml'));
+
+        // Persons, boundaries and external systems must be emitted.
+        expect(xml, 'Person "dev" not emitted').toContain('id="dev"');
+        expect(xml, 'Workstation boundary not emitted').toContain('id="host"');
+        expect(xml, 'System_Ext "docker" not emitted').toContain('id="docker"');
+        expect(xml, 'System_Ext "registries" not emitted').toContain('id="registries"');
+        expect(xml, 'System_Ext "charts" not emitted').toContain('id="charts"');
+
+        // All 4 relationships should survive (one is 4-arg, three are 3-arg).
+        const edges = [...xml.matchAll(/source="([^"]+)"\s+target="([^"]+)"/g)];
+        const pairs = new Set(edges.map((m) => `${m[1]}->${m[2]}`));
+        expect(pairs.has('dev->kind')).toBe(true);
+        expect(pairs.has('kind->docker')).toBe(true);
+        expect(pairs.has('kind->registries')).toBe(true);
+        expect(pairs.has('kind->charts')).toBe(true);
+    });
+
+    it('preserves ContainerDb + nested boundaries + all 6 Rels in c4-container', async () => {
+        const xml = await Catalyst.convert(fixture('c4-container.puml'));
+
+        // Leaf containers + ContainerDb + Person.
+        for (const alias of ['dev', 'docker', 'cp', 'worker', 'ingress', 'lb', 'metrics', 'dash', 'nfs', 'prom', 'apps']) {
+            expect(xml, `alias "${alias}" not emitted`).toContain(`id="${alias}"`);
+        }
+
+        // Both System_Boundary wrappers.
+        expect(xml, 'host boundary not emitted').toContain('id="host"');
+        expect(xml, 'kind boundary not emitted').toContain('id="kind"');
+
+        // All 6 relationships (4 are 3-arg, 2 are 4-arg).
+        const edges = [...xml.matchAll(/source="([^"]+)"\s+target="([^"]+)"/g)];
+        const pairs = new Set(edges.map((m) => `${m[1]}->${m[2]}`));
+        for (const pair of ['dev->docker', 'dev->ingress', 'dev->lb', 'ingress->apps', 'lb->apps', 'apps->nfs']) {
+            expect(pairs.has(pair), `relationship "${pair}" missing`).toBe(true);
+        }
+    });
+});

--- a/tests/fixtures/c4-container.puml
+++ b/tests/fixtures/c4-container.puml
@@ -1,0 +1,38 @@
+@startuml c4-container
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/v2.10.0/C4_Container.puml
+
+title Container View — kind-cluster
+
+Person(dev, "Developer")
+
+System_Boundary(host, "Host or Multipass VM") {
+  Container(docker, "Docker Engine", "containerd", "Hosts KinD nodes")
+
+  System_Boundary(kind, "KinD cluster") {
+    Container(cp, "control-plane node", "kindest/node v1.35.0", "API server, scheduler, etcd, kubelet")
+    Container(worker, "worker node", "kindest/node v1.35.0", "Pod runtime")
+
+    Container(ingress, "ingress-nginx", "Helm chart", "L7 routing; pinned to control-plane via nodeSelector")
+    Container(lb, "cloud-provider-kind", "docker container on kind network", "Allocates LoadBalancer IPs (primary; MetalLB alternative via LB=metallb)")
+    Container(metrics, "metrics-server", "manifest", "Serves metrics.k8s.io for kubectl top / HPA")
+    Container(dash, "Kubernetes Dashboard", "Helm chart v7.x, Kong proxy", "https://localhost:8443 via port-forward")
+    ContainerDb(nfs, "NFS server + csi-driver-nfs", "in-cluster pod or host NFS", "ReadWriteMany PVCs")
+    Container(prom, "kube-prometheus-stack", "Helm chart", "Prometheus + Grafana + Alertmanager")
+    Container(apps, "Demo workloads", "httpd / hello-app / golang-web / http-echo", "Routed via ingress + LoadBalancer Services")
+  }
+}
+
+Rel(dev, docker, "docker / kind CLI")
+Rel(dev, ingress, "HTTP via Host: demo.localdev.me", "127.0.0.1")
+Rel(dev, lb, "HTTP to LoadBalancer IPs (host-routable via docker bridge)")
+Rel(ingress, apps, "Routes /")
+Rel(lb, apps, "Allocates LoadBalancer IP")
+Rel(apps, nfs, "Mounts RWX PVCs (optional)")
+
+Lay_D(docker, kind)
+Lay_R(cp, worker)
+Lay_D(ingress, apps)
+Lay_R(lb, apps)
+
+SHOW_LEGEND()
+@enduml

--- a/tests/fixtures/c4-context.puml
+++ b/tests/fixtures/c4-context.puml
@@ -1,0 +1,22 @@
+@startuml c4-context
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/v2.10.0/C4_Context.puml
+
+title System Context — kind-cluster
+
+Person(dev, "Developer", "Runs make targets to bring up a local k8s lab")
+
+System_Boundary(host, "Workstation or Multipass VM") {
+  System(kind, "kind-cluster", "Local KinD stack: ingress, cloud-provider-kind, Dashboard, NFS, Prometheus")
+  System_Ext(docker, "Docker", "Container runtime hosting the KinD nodes")
+}
+
+System_Ext(registries, "Container registries", "Docker Hub, GHCR, k8s.gcr.io, quay.io")
+System_Ext(charts, "Helm chart repos", "ingress-nginx, kube-prometheus, dashboard, csi-driver-nfs")
+
+Rel(dev, kind, "make kind-up / kind-down", "shell + kubectl")
+Rel(kind, docker, "Runs nodes as containers")
+Rel(kind, registries, "Pulls workload images")
+Rel(kind, charts, "helm install/upgrade")
+
+SHOW_LEGEND()
+@enduml


### PR DESCRIPTION
## Summary

Previously `layoutData2mx` only dispatched `System` / `Container` / `Component` cases; 17 other valid C4 element types (returned by `EntityParser.isValidEntityType`) hit `default: break` and vanished from the output. This PR:

- Adds shape classes under `mx/c4/` for `Person`, `PersonExt`, `SystemExt`, `ContainerDb`, `Boundary` — each follows the existing static `label`/`style`/`encodeHtmlEntities` pattern used by `Container.mts`.
- Broadens the `Mx.addMxC4` switch to handle every type returned by `EntityParser`. Types without dedicated shape classes reuse sensible approximations (DB/Queue variants → `ContainerDb` cylinder; `_Ext` variants → `SystemExt` grey).
- Adds an optional `parent` param on `addMxC4` so children of `System_Boundary` / `Container_Boundary` end up **inside** the boundary in drawio (proper containment via `mxCell.parent`).
- `catalyst.layoutData2mx` now walks the entity hierarchy once to build a parent-alias map, passes every layout node/cluster through to `addMxC4`, and relies on the switch for type-specific rendering.
- Ships `tests/fixtures/c4-context.puml` and `tests/fixtures/c4-container.puml` (real-world C4 diagrams that exercise Persons, System_Ext, nested boundaries, ContainerDb, and both 3-arg and 4-arg Rels) with `tests/export-gaps.test.mts` asserting every previously-dropped element survives.

## Dependency note

Stacks cleanly on top of #555, #556, #557. If reviewed together, the stack is:

1. #555 (rel regex) — covers the 3-arg Rels this PR's fixture depends on
2. #556 (diagram id) — unblocks `drawio-export` consumers of the output
3. #557 (boundaries + paren-aware parsing) — produces the entity stream this PR renders
4. **this PR** — renders it

## Test plan

- [x] All 110 tests pass (107 existing + 3 new integration tests)
- [x] Visual comparison with plantuml side-by-side (PNGs produced via [puml2drawio `make diagrams-png`](https://github.com/AndriyKalashnykov/puml2drawio/blob/main/scripts/diagrams-png.sh)) shows all 16 shapes + 6 edges present in `c4-container.puml`, all 5 shapes + 4 edges present in `c4-context.puml` — vs 8 / 1 and 1 / 1 previously.

Refs: #554 (gap 3/5).